### PR TITLE
bug fix in cg_sites_from_fasta()

### DIFF
--- a/aligned_bam_to_cpg_scores.py
+++ b/aligned_bam_to_cpg_scores.py
@@ -165,6 +165,8 @@ def cg_sites_from_fasta(input_fasta, ref):
     :return cg_sites_ref_set: Set with all CG ref positions. (set)
     """
     # open fasta with BioPython and iterated over records
+    cg_sites_ref_set = set()
+
     with open(input_fasta) as fh:
         for record in SeqIO.parse(fh, "fasta"):
             # if record name matches this particular ref,


### PR DESCRIPTION
If a reference region in the bam file does not match any reference region in the reference fasta file, an error may be thrown. Adding empty set fixes this issue.