### PR TITLE
Update numpy version for pandas compatability

### DIFF
--- a/conda_env_cpg.yaml
+++ b/conda_env_cpg.yaml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python=3.9
   - tensorflow=2.7
-  - numpy=1.20.0
+  - numpy=1.20
   - biopython
   - pandas
   - pysam


### PR DESCRIPTION
Closes #38 by allowing newer version of numpy for compatibility with newer versions of pandas.

Tested in https://github.com/PacificBiosciences/pb-human-wgs-workflow-snakemake/pull/159/commits/7449520e38fb3bd99b8cbdb45ddb1cb8482e13f3 and works.